### PR TITLE
Refine UI with modern dark layout and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,19 +30,14 @@
                 <span class="visually-hidden">Toggle navigation</span>
             </button>
             <div class="app-brand">
-                <h1 class="app-title"><i class="fas fa-magic" aria-hidden="true"></i> AI Prompt Generator v2.0</h1>
-                <span class="badge badge--accent">Advanced</span>
+                <span class="app-brand__badge">AI Prompt Suite</span>
+                <h1 class="app-title">AI Prompt Generator</h1>
             </div>
         </div>
-        <div class="app-header__end">
-            <div class="header-actions">
-                <button class="btn btn--outline btn--compact" type="button" data-header-collaborate>
-                    <i class="fas fa-users" aria-hidden="true"></i> Collaborate
-                </button>
-                <a class="btn btn--outline btn--compact" href="#" data-header-mini>
-                    <i class="fas fa-bolt" aria-hidden="true"></i> Chota Dhamakaa
-                </a>
-            </div>
+        <div class="app-header__actions">
+            <button class="icon-button" type="button" id="header-help" aria-label="Open help center">
+                <i class="fas fa-circle-info" aria-hidden="true"></i>
+            </button>
         </div>
     </header>
 
@@ -56,17 +51,17 @@
                 </button>
             </header>
             <nav class="drawer__nav" aria-label="Primary">
-                <button class="drawer__link" data-drawer-tab="manual" type="button"><i class="fas fa-edit" aria-hidden="true"></i> Manual Builder</button>
+                <button class="drawer__link" data-drawer-tab="prompt-builder" type="button"><i class="fas fa-pen" aria-hidden="true"></i> Prompt Builder</button>
                 <button class="drawer__link" data-drawer-tab="image-to-prompt" type="button"><i class="fas fa-image" aria-hidden="true"></i> Image to Prompt</button>
-                <button class="drawer__link" data-drawer-tab="batch-generator" type="button"><i class="fas fa-clone" aria-hidden="true"></i> Batch Generator</button>
-                <button class="drawer__link" data-drawer-tab="mini-generator" type="button"><i class="fas fa-bolt" aria-hidden="true"></i> Chota Dhamakaa</button>
+                <button class="drawer__link" data-drawer-tab="image-generator" type="button"><i class="fas fa-wand-magic-sparkles" aria-hidden="true"></i> Image Generator</button>
+                <button class="drawer__link" data-drawer-tab="more-tools" type="button"><i class="fas fa-toolbox" aria-hidden="true"></i> More Tools</button>
             </nav>
             <div class="drawer__actions">
                 <button class="btn btn--secondary btn--full-width" type="button" data-drawer-collaborate>
-                    <i class="fas fa-users" aria-hidden="true"></i> Collaborate
+                    <i class="fas fa-share-nodes" aria-hidden="true"></i> Share Prompt
                 </button>
                 <button class="btn btn--outline btn--full-width" type="button" data-drawer-mini>
-                    <i class="fas fa-bolt" aria-hidden="true"></i> Chota Dhamakaa
+                    <i class="fas fa-bolt" aria-hidden="true"></i> Quick Generator
                 </button>
             </div>
         </div>
@@ -74,7 +69,7 @@
     <div class="scrim" id="scrim" hidden></div>
 
     <div class="app-shell">
-        <section class="control-strip" aria-label="Controls">
+        <section class="control-strip" aria-label="Workspace controls">
             <span class="control-strip__pill" aria-hidden="true">Advanced</span>
             <div class="control-strip__group control-strip__group--platform">
                 <label class="control-strip__label" for="platform-select"><i class="fas fa-cogs" aria-hidden="true"></i> Platform</label>
@@ -89,7 +84,7 @@
                 </div>
             </div>
             <div class="control-strip__group control-strip__group--themes">
-                <span class="control-strip__label">Themes</span>
+                <span class="control-strip__label"><i class="fas fa-palette" aria-hidden="true"></i> Quick Themes</span>
                 <div class="chip-carousel" role="listbox" aria-label="Theme selection">
                     <button class="chip theme-chip is-active" type="button" role="option" aria-selected="true" data-theme="cyberpunk_neon">Cyberpunk</button>
                     <button class="chip theme-chip" type="button" role="option" aria-selected="false" data-theme="dark_professional">Dark</button>
@@ -114,10 +109,10 @@
             </div>
             <div class="control-strip__actions">
                 <button class="btn btn--outline btn--compact" type="button" id="collaboration-btn">
-                    <i class="fas fa-users" aria-hidden="true"></i> Collaborate
+                    <i class="fas fa-share-nodes" aria-hidden="true"></i> Share
                 </button>
-                <a class="btn btn--outline btn--compact" id="mini-generator-link" href="#">
-                    <i class="fas fa-bolt" aria-hidden="true"></i> Chota Dhamakaa
+                <a class="btn btn--outline btn--compact" id="mini-generator-link" href="#" data-header-mini>
+                    <i class="fas fa-bolt" aria-hidden="true"></i> Quick Gen
                 </a>
             </div>
         </section>
@@ -214,31 +209,19 @@
                 </aside>
 
                 <section class="app-main main-content" aria-label="Prompt builder">
-                    <nav class="tabs" role="tablist" aria-label="Workspace views">
-                        <button class="tab active" data-tab="manual" role="tab" aria-selected="true" aria-controls="manual-tab">
-                            <i class="fas fa-edit" aria-hidden="true"></i> Manual Builder
-                        </button>
-                        <button class="tab" data-tab="image-to-prompt" role="tab" aria-selected="false" aria-controls="image-to-prompt-tab">
-                            <i class="fas fa-image" aria-hidden="true"></i> Image to Prompt
-                        </button>
-                        <button class="tab" data-tab="batch-generator" role="tab" aria-selected="false" aria-controls="batch-generator-tab">
-                            <i class="fas fa-clone" aria-hidden="true"></i> Batch Generator
-                        </button>
-                        <button class="tab" data-tab="mini-generator" role="tab" aria-selected="false" aria-controls="mini-generator-tab">
-                            <i class="fas fa-bolt" aria-hidden="true"></i> Chota Dhamakaa
-                        </button>
-                    </nav>
-
-                    <section class="tab-content active" id="manual-tab" role="tabpanel" aria-labelledby="manual" tabindex="0">
+                    <section class="tab-content active" id="prompt-builder-tab" role="tabpanel" aria-labelledby="tab-prompt-builder" tabindex="0">
                         <article class="prompt-workspace">
                             <header class="workspace-header">
-                                <h2 class="workspace-title">Build Your Prompt</h2>
+                                <div>
+                                    <p class="workspace-eyebrow">Prompt Builder</p>
+                                    <h2 class="workspace-title">Build your perfect prompt</h2>
+                                </div>
                                 <div class="workspace-actions">
                                     <button class="btn btn--sm btn--outline" id="clear-prompt" type="button">
                                         <i class="fas fa-trash" aria-hidden="true"></i> Clear
                                     </button>
                                     <button class="btn btn--sm btn--outline" id="optimize-prompt" type="button">
-                                        <i class="fas fa-magic" aria-hidden="true"></i> Auto-Optimize
+                                        <i class="fas fa-wand-magic-sparkles" aria-hidden="true"></i> Enhance Now
                                     </button>
                                     <button class="btn btn--sm btn--secondary" id="voice-input" type="button">
                                         <i class="fas fa-microphone" aria-hidden="true"></i> Voice Input
@@ -247,19 +230,47 @@
                             </header>
 
                             <div class="prompt-settings">
-                                <label for="prompt-length">Prompt Length</label>
-                                <input type="range" id="prompt-length" min="100" max="700" step="100" value="300">
-                                <span class="prompt-length-display" id="prompt-length-display">Medium</span>
+                                <div class="range-field">
+                                    <div class="range-field__label">
+                                        <label for="prompt-length">Prompt Length</label>
+                                        <span class="range-value" id="prompt-length-display">Medium</span>
+                                    </div>
+                                    <input type="range" id="prompt-length" min="100" max="700" step="100" value="300">
+                                </div>
+                                <div class="segment-card">
+                                    <span class="segment-card__label">Image Dimensions</span>
+                                    <div class="segmented-group" id="aspect-ratio-group" role="group" aria-label="Image aspect ratios">
+                                        <button type="button" class="segment is-active" data-aspect="1:1">1:1</button>
+                                        <button type="button" class="segment" data-aspect="3:4">3:4</button>
+                                        <button type="button" class="segment" data-aspect="4:3">4:3</button>
+                                        <button type="button" class="segment" data-aspect="9:16">9:16</button>
+                                        <button type="button" class="segment" data-aspect="16:9">16:9</button>
+                                    </div>
+                                </div>
                             </div>
 
                             <div class="prompt-editor">
                                 <label class="visually-hidden" for="prompt-textarea">Prompt text</label>
-                                <textarea
-                                    id="prompt-textarea"
-                                    class="prompt-textarea"
-                                    placeholder="Describe your vision... (or use voice input or drag words)"
-                                    rows="8"
-                                ></textarea>
+                                <div class="prompt-textarea__wrapper">
+                                    <textarea
+                                        id="prompt-textarea"
+                                        class="prompt-textarea"
+                                        placeholder="Enter your prompt"
+                                        rows="8"
+                                        maxlength="2000"
+                                    ></textarea>
+                                    <button class="clear-field" type="button" id="clear-field" aria-label="Clear prompt input">
+                                        <i class="fas fa-times" aria-hidden="true"></i>
+                                    </button>
+                                    <span class="char-counter" id="char-count">0/2000</span>
+                                </div>
+                                <div class="enhance-toggle">
+                                    <label class="toggle" for="magic-enhance-toggle">
+                                        <input type="checkbox" id="magic-enhance-toggle">
+                                        <span class="toggle__indicator" aria-hidden="true"></span>
+                                        <span class="toggle__label">Magic Enhance</span>
+                                    </label>
+                                </div>
                                 <div class="editor-status" aria-live="polite">
                                     <span class="status-pill" id="word-count">0 words</span>
                                     <span class="status-pill" id="quality-indicator">Quality: GOOD (65%)</span>
@@ -275,25 +286,50 @@
                         </article>
                     </section>
 
-                    <section class="tab-content" id="image-to-prompt-tab" role="tabpanel" aria-labelledby="image-to-prompt" tabindex="0">
-                        <div class="image-upload-area">
-                            <div class="upload-section">
-                                <h2>AI-Powered Image Analysis</h2>
-                                <p>Upload an image and get an optimized prompt instantly</p>
-
+                    <section class="tab-content" id="image-to-prompt-tab" role="tabpanel" aria-labelledby="tab-image-to-prompt" tabindex="0">
+                        <div class="image-prompt-grid">
+                            <article class="upload-card">
+                                <header class="card-header">
+                                    <div>
+                                        <p class="workspace-eyebrow">Image Analysis</p>
+                                        <h2>Convert image to prompt</h2>
+                                    </div>
+                                    <p class="card-subtitle">Upload an image for instant prompt suggestions.</p>
+                                </header>
                                 <div class="upload-zone" id="upload-zone">
                                     <label class="upload-content" for="image-upload">
-                                        <i class="fas fa-cloud-upload-alt upload-icon" aria-hidden="true"></i>
-                                        <h3>Drop an image here or tap to browse</h3>
-                                        <p>Supports JPG, PNG, WebP up to 10MB</p>
-                                        <span class="upload-button">Browse Files</span>
+                                        <div class="upload-placeholder" aria-hidden="true">
+                                            <i class="fas fa-image" aria-hidden="true"></i>
+                                            <p>Tap to upload image</p>
+                                            <span class="upload-button">Upload Image</span>
+                                        </div>
                                     </label>
                                     <input type="file" id="image-upload" accept="image/*">
                                 </div>
-
-                                <p class="upload-guidance">Max size 10MB • Drag-and-drop friendly</p>
-
+                                <p class="upload-guidance">Supports JPG, PNG, WebP up to 10MB</p>
                                 <div class="upload-status" id="upload-status" aria-live="polite"></div>
+
+                                <div class="description-card">
+                                    <div class="description-card__header">
+                                        <h3>Description Type</h3>
+                                        <p>Choose how the AI should describe your image.</p>
+                                    </div>
+                                    <div class="description-grid" id="description-grid" role="group" aria-label="Description styles">
+                                        <button type="button" class="description-option is-active" data-description="describe-detail">Describe Image in Detail</button>
+                                        <button type="button" class="description-option" data-description="describe-brief">Describe Briefly</button>
+                                        <button type="button" class="description-option" data-description="person-description">Person Description</button>
+                                        <button type="button" class="description-option" data-description="object-recognition">Object Recognition</button>
+                                        <button type="button" class="description-option" data-description="art-style">Art Style Analysis</button>
+                                        <button type="button" class="description-option" data-description="text-extraction">Text Extraction</button>
+                                        <button type="button" class="description-option" data-description="midjourney">Midjourney Prompt</button>
+                                        <button type="button" class="description-option" data-description="stable-diffusion">Stable Diffusion Prompt</button>
+                                        <button type="button" class="description-option" data-description="custom-question">Custom Question</button>
+                                    </div>
+                                    <div class="custom-question" id="custom-question-field" hidden>
+                                        <label for="custom-question-input">Custom question</label>
+                                        <input type="text" id="custom-question-input" class="form-control" placeholder="What do you want to know about the image?">
+                                    </div>
+                                </div>
 
                                 <div class="uploaded-image" id="preview-container" hidden>
                                     <h3>Image Preview</h3>
@@ -301,25 +337,31 @@
                                         <img id="uploaded-img" src="" alt="Uploaded image preview" loading="lazy">
                                     </div>
                                 </div>
-                            </div>
+                            </article>
 
-                            <div class="analysis-results" id="analysis-results" hidden>
-                                <h3>AI Analysis Results</h3>
+                            <article class="analysis-card" id="analysis-results" hidden>
+                                <header class="card-header">
+                                    <h3>AI Analysis Results</h3>
+                                </header>
                                 <div class="analysis-tags" id="analysis-tags">
                                     <!-- AI-detected tags -->
                                 </div>
-
                                 <div class="generated-prompt">
                                     <div class="output-header">
                                         <span>Output</span>
                                         <label class="nl-option"><input type="checkbox" id="natural-language-toggle" checked> Natural Language</label>
                                     </div>
                                     <textarea id="generated-prompt-text" class="form-control" rows="4"></textarea>
-                                    <button class="btn btn--primary btn--full-width" id="use-generated-prompt" type="button">
-                                        <i class="fas fa-check" aria-hidden="true"></i> Use This Prompt
-                                    </button>
+                                    <div class="generated-actions">
+                                        <button class="btn btn--primary btn--full-width" id="use-generated-prompt" type="button">
+                                            <i class="fas fa-check" aria-hidden="true"></i> Use This Prompt
+                                        </button>
+                                        <button class="btn btn--outline btn--full-width" id="copy-generated-prompt" type="button">
+                                            <i class="fas fa-copy" aria-hidden="true"></i> Copy Prompt
+                                        </button>
+                                    </div>
                                 </div>
-                            </div>
+                            </article>
                         </div>
 
                         <div id="hf-image-to-prompt-container" class="hf-embed">
@@ -335,53 +377,93 @@
                         </div>
                     </section>
 
-                    <section class="tab-content" id="batch-generator-tab" role="tabpanel" aria-labelledby="batch-generator" tabindex="0">
-                        <article class="batch-section">
-                            <h2>Batch Prompt Generator</h2>
-                            <p>Generate multiple variations of prompts for A/B testing</p>
-
-                            <div class="batch-controls">
-                                <div class="form-group">
-                                    <label for="batch-base-prompt">Base Prompt</label>
-                                    <textarea id="batch-base-prompt" class="form-control" rows="3" placeholder="Enter your base prompt..."></textarea>
-                                </div>
-
-                                <div class="batch-settings">
-                                    <div class="form-group">
-                                        <label for="batch-count">Number of Variations</label>
-                                        <select id="batch-count" class="form-control">
-                                            <option value="5">5 variations</option>
-                                            <option value="10">10 variations</option>
-                                            <option value="20">20 variations</option>
-                                            <option value="50">50 variations</option>
-                                        </select>
-                                    </div>
-
-                                    <div class="form-group">
-                                        <label for="variation-type">Variation Type</label>
-                                        <select id="variation-type" class="form-control">
-                                            <option value="style">Style Variations</option>
-                                            <option value="lighting">Lighting Variations</option>
-                                            <option value="composition">Composition Variations</option>
-                                            <option value="color">Color Variations</option>
-                                            <option value="mixed">Mixed Variations</option>
-                                        </select>
-                                    </div>
-                                </div>
-
-                                <button class="btn btn--primary btn--full-width" id="generate-batch" type="button">
-                                    <i class="fas fa-magic" aria-hidden="true"></i> Generate Batch
-                                </button>
-                            </div>
-
-                            <div class="batch-results" id="batch-results" aria-live="polite">
-                                <!-- Generated variations will appear here -->
-                            </div>
+                    <section class="tab-content" id="image-generator-tab" role="tabpanel" aria-labelledby="tab-image-generator" tabindex="0">
+                        <article class="embed-card">
+                            <header class="card-header">
+                                <p class="workspace-eyebrow">Quick Ideas</p>
+                                <h2>Image Prompt Generator</h2>
+                                <p class="card-subtitle">Use the lightweight generator for rapid inspiration.</p>
+                            </header>
+                            <iframe src="classicpg/index.html" class="mini-frame" title="Quick image prompt generator"></iframe>
                         </article>
                     </section>
 
-                    <section class="tab-content" id="mini-generator-tab" role="tabpanel" aria-labelledby="mini-generator" tabindex="0">
-                        <iframe src="classicpg/index.html" class="mini-frame" title="Chota Dhamakaa mini generator"></iframe>
+                    <section class="tab-content" id="more-tools-tab" role="tabpanel" aria-labelledby="tab-more-tools" tabindex="0">
+                        <div class="more-tools-grid">
+                            <article class="batch-section">
+                                <header class="card-header">
+                                    <p class="workspace-eyebrow">Batch Tools</p>
+                                    <h2>Batch Prompt Generator</h2>
+                                    <p class="card-subtitle">Generate multiple variations of prompts for A/B testing.</p>
+                                </header>
+                                <div class="batch-controls">
+                                    <div class="form-group">
+                                        <label for="batch-base-prompt">Base Prompt</label>
+                                        <textarea id="batch-base-prompt" class="form-control" rows="3" placeholder="Enter your base prompt..."></textarea>
+                                    </div>
+                                    <div class="batch-settings">
+                                        <div class="form-group">
+                                            <label for="batch-count">Number of Variations</label>
+                                            <select id="batch-count" class="form-control">
+                                                <option value="5">5 variations</option>
+                                                <option value="10">10 variations</option>
+                                                <option value="20">20 variations</option>
+                                                <option value="50">50 variations</option>
+                                            </select>
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="variation-type">Variation Type</label>
+                                            <select id="variation-type" class="form-control">
+                                                <option value="style">Style Variations</option>
+                                                <option value="lighting">Lighting Variations</option>
+                                                <option value="composition">Composition Variations</option>
+                                                <option value="color">Color Variations</option>
+                                                <option value="mixed">Mixed Variations</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <button class="btn btn--primary btn--full-width" id="generate-batch" type="button">
+                                        <i class="fas fa-magic" aria-hidden="true"></i> Generate Batch
+                                    </button>
+                                </div>
+                                <div class="batch-results" id="batch-results" aria-live="polite">
+                                    <!-- Generated variations will appear here -->
+                                </div>
+                            </article>
+
+                            <article class="actions-card">
+                                <header class="card-header">
+                                    <p class="workspace-eyebrow">Prompt Actions</p>
+                                    <h2>Manage &amp; Share</h2>
+                                </header>
+                                <div class="action-toolbar" role="group" aria-label="Prompt actions">
+                                    <div class="copy-action">
+                                        <button class="btn btn--secondary" id="copy-prompt" type="button">
+                                            <i class="fas fa-copy" aria-hidden="true"></i> Copy Prompt
+                                        </button>
+                                        <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>
+                                    </div>
+                                    <button class="btn btn--primary" id="save-prompt" type="button">
+                                        <i class="fas fa-save" aria-hidden="true"></i> Save Prompt
+                                    </button>
+                                    <button class="btn btn--outline" type="button" data-header-collaborate>
+                                        <i class="fas fa-share-nodes" aria-hidden="true"></i> Share Prompt
+                                    </button>
+                                    <button class="btn btn--outline" type="button" data-header-mini>
+                                        <i class="fas fa-bolt" aria-hidden="true"></i> Quick Generator
+                                    </button>
+                                    <button class="btn btn--outline" id="export-txt" type="button">
+                                        <i class="fas fa-file-export" aria-hidden="true"></i> Export .txt
+                                    </button>
+                                    <button class="btn btn--outline" id="share-prompt" type="button">
+                                        <i class="fas fa-share-alt" aria-hidden="true"></i> Share Link
+                                    </button>
+                                    <button class="btn btn--outline" id="analyze-prompt" type="button">
+                                        <i class="fas fa-chart-line" aria-hidden="true"></i> Deep Analysis
+                                    </button>
+                                </div>
+                            </article>
+                        </div>
                     </section>
                 </section>
 
@@ -425,41 +507,6 @@
                         </div>
                     </section>
 
-                    <section class="panel" aria-labelledby="actions-heading">
-                        <div class="panel__header">
-                            <h3 id="actions-heading"><i class="fas fa-tools" aria-hidden="true"></i> Actions</h3>
-                        </div>
-                        <div class="panel__body">
-                            <div class="action-toolbar" role="group" aria-label="Prompt actions">
-                                <div class="copy-action">
-                                    <button class="btn btn--secondary" id="copy-prompt" type="button">
-                                        <i class="fas fa-copy" aria-hidden="true"></i> Copy
-                                    </button>
-                                    <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>
-                                </div>
-                                <button class="btn btn--primary" id="save-prompt" type="button">
-                                    <i class="fas fa-save" aria-hidden="true"></i> Save
-                                </button>
-                                <details class="more-actions">
-                                    <summary class="btn btn--outline" role="button" aria-haspopup="true">
-                                        <i class="fas fa-ellipsis-h" aria-hidden="true"></i> More
-                                    </summary>
-                                    <div class="more-actions__menu" role="menu">
-                                        <button class="btn btn--outline btn--full-width" id="export-txt" type="button" role="menuitem">
-                                            <i class="fas fa-file-export" aria-hidden="true"></i> Export .txt
-                                        </button>
-                                        <button class="btn btn--outline btn--full-width" id="share-prompt" type="button" role="menuitem">
-                                            <i class="fas fa-share-alt" aria-hidden="true"></i> Share Link
-                                        </button>
-                                        <button class="btn btn--outline btn--full-width" id="analyze-prompt" type="button" role="menuitem">
-                                            <i class="fas fa-chart-line" aria-hidden="true"></i> Deep Analysis
-                                        </button>
-                                    </div>
-                                </details>
-                            </div>
-                        </div>
-                    </section>
-
                     <section class="panel" aria-labelledby="saved-prompts-heading">
                         <div class="panel__header">
                             <h3 id="saved-prompts-heading"><i class="fas fa-bookmark" aria-hidden="true"></i> Saved Prompts</h3>
@@ -474,6 +521,25 @@
             </div>
         </main>
     </div>
+
+    <nav class="bottom-nav tabs" role="tablist" aria-label="Primary navigation">
+        <button class="tab active" id="tab-prompt-builder" data-tab="prompt-builder" role="tab" aria-selected="true" aria-controls="prompt-builder-tab">
+            <i class="fas fa-pen" aria-hidden="true"></i>
+            <span>Prompt Builder</span>
+        </button>
+        <button class="tab" id="tab-image-to-prompt" data-tab="image-to-prompt" role="tab" aria-selected="false" aria-controls="image-to-prompt-tab">
+            <i class="fas fa-image" aria-hidden="true"></i>
+            <span>Image to Prompt</span>
+        </button>
+        <button class="tab" id="tab-image-generator" data-tab="image-generator" role="tab" aria-selected="false" aria-controls="image-generator-tab">
+            <i class="fas fa-wand-magic-sparkles" aria-hidden="true"></i>
+            <span>Image Generator</span>
+        </button>
+        <button class="tab" id="tab-more-tools" data-tab="more-tools" role="tab" aria-selected="false" aria-controls="more-tools-tab">
+            <i class="fas fa-toolbox" aria-hidden="true"></i>
+            <span>More Tools</span>
+        </button>
+    </nav>
 
     <div class="modal hidden" id="save-modal" role="dialog" aria-modal="true" aria-labelledby="save-modal-title">
         <div class="modal__container">

--- a/styles/base.css
+++ b/styles/base.css
@@ -41,6 +41,9 @@
   --transition-base: 220ms ease;
   --transition-slow: 320ms ease;
 
+  /* Accent colors */
+  --accent-blue: #3a7afe;
+
   /* Z-index scale */
   --z-base: 1;
   --z-header: 900;
@@ -51,17 +54,17 @@
 
 /* Theme palettes applied via data-theme attribute */
 [data-theme='cyberpunk_neon'] {
-  --theme-primary: #00ff88;
-  --theme-secondary: #111111;
-  --theme-accent: #ff0080;
-  --theme-background: #050505;
-  --theme-surface: #161616;
-  --theme-elevated: rgba(17, 17, 17, 0.85);
-  --theme-text: #f7fff9;
-  --theme-text-muted: #8dffd0;
-  --theme-border: rgba(0, 255, 136, 0.25);
-  --theme-focus: rgba(0, 255, 136, 0.65);
-  --theme-success: #00ff88;
+  --theme-primary: #1db954;
+  --theme-secondary: #0b0b0b;
+  --theme-accent: var(--accent-blue);
+  --theme-background: #111111;
+  --theme-surface: #1e1e1e;
+  --theme-elevated: #242424;
+  --theme-text: #f5f7f8;
+  --theme-text-muted: #b0b6ba;
+  --theme-border: rgba(255, 255, 255, 0.08);
+  --theme-focus: rgba(29, 185, 84, 0.6);
+  --theme-success: #1db954;
   --theme-warning: #ffb02e;
   --theme-error: #ff4d8d;
 }

--- a/styles/components/buttons.css
+++ b/styles/components/buttons.css
@@ -14,6 +14,8 @@
   color: var(--theme-text);
   font-weight: 600;
   line-height: 1.2;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
   transition: transform var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
   text-align: center;
 }
@@ -47,7 +49,7 @@
 
 .btn--outline {
   background: transparent;
-  border-color: var(--theme-border);
+  border-color: rgba(255, 255, 255, 0.16);
 }
 
 .btn--full-width {

--- a/styles/components/cards.css
+++ b/styles/components/cards.css
@@ -1,16 +1,16 @@
 /* Panels, cards, and list styling */
 
 .panel {
-  background: var(--theme-surface);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--theme-border);
-  box-shadow: var(--shadow-sm);
+  background: rgba(24, 24, 24, 0.9);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
   overflow: hidden;
 }
 
 .panel__header {
   padding: var(--space-md);
-  border-bottom: 1px solid var(--theme-border);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .panel__body {
@@ -27,7 +27,7 @@
   gap: var(--space-sm);
   padding: var(--space-md);
   cursor: pointer;
-  background: var(--theme-surface);
+  background: transparent;
 }
 
 .panel__summary::-webkit-details-marker {
@@ -56,7 +56,7 @@
   gap: var(--space-sm);
   padding: var(--space-sm);
   border-radius: var(--radius-md);
-  border: 1px dashed var(--theme-border);
+  border: 1px dashed rgba(255, 255, 255, 0.12);
 }
 
 .random-btn {
@@ -66,8 +66,8 @@
   gap: var(--space-sm);
   padding: var(--space-sm);
   border-radius: var(--radius-md);
-  border: 1px solid var(--theme-border);
-  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
   min-height: 48px;
   font-weight: 600;
   transition: transform var(--transition-fast), box-shadow var(--transition-fast);
@@ -93,7 +93,7 @@
   min-height: 44px;
   padding: 0.5rem var(--space-sm);
   border-radius: var(--radius-pill);
-  border: 1px solid var(--theme-border);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.04);
   color: var(--theme-text);
   font-size: var(--text-sm);
@@ -147,7 +147,7 @@
   gap: var(--space-xs);
   padding: var(--space-sm);
   border-radius: var(--radius-md);
-  border: 1px solid var(--theme-border);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.03);
   box-shadow: var(--shadow-sm);
 }
@@ -179,7 +179,7 @@
   gap: var(--space-2xs);
   padding: var(--space-sm);
   border-radius: var(--radius-md);
-  border: 1px solid var(--theme-border);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.03);
 }
 
@@ -247,3 +247,85 @@
   }
 }
 
+
+/* Modern card layouts */
+.prompt-workspace,
+.batch-section,
+.upload-card,
+.analysis-card,
+.embed-card,
+.actions-card {
+  background: linear-gradient(180deg, rgba(34, 34, 34, 0.95), rgba(17, 17, 17, 0.92));
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  padding: clamp(1.5rem, 2vw, 2.75rem);
+  box-shadow: 0 24px 55px rgba(0, 0, 0, 0.45);
+}
+
+.workspace-eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--theme-text-muted);
+}
+
+.card-header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.card-subtitle {
+  color: var(--theme-text-muted);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.image-prompt-grid {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.more-tools-grid {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.generated-actions {
+  display: grid;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+}
+
+.analysis-card {
+  display: grid;
+  gap: var(--space-md);
+}
+
+.actions-card .action-toolbar {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.actions-card .action-toolbar > * {
+  width: 100%;
+}
+
+@media (min-width: 52rem) {
+  .image-prompt-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
+  }
+
+  .more-tools-grid {
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  }
+
+  .actions-card .action-toolbar {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 72rem) {
+  .actions-card .action-toolbar {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/styles/components/dropzone.css
+++ b/styles/components/dropzone.css
@@ -1,19 +1,20 @@
 /* Upload zone styling */
 
 .upload-zone {
-  border: 2px dashed var(--theme-border);
-  border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.03);
-  padding: var(--space-lg);
+  border: 2px dashed rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.02);
+  padding: clamp(1.25rem, 3vw, 2rem);
   text-align: center;
-  transition: border-color var(--transition-fast), background var(--transition-fast);
+  transition: border-color var(--transition-fast), background var(--transition-fast), transform var(--transition-fast);
   position: relative;
 }
 
 .upload-zone:focus-within,
 .upload-zone:hover {
   border-color: var(--theme-primary);
-  background: rgba(0, 255, 136, 0.08);
+  background: rgba(29, 185, 84, 0.15);
+  transform: translateY(-2px);
 }
 
 .upload-zone input[type='file'] {
@@ -27,34 +28,38 @@
 
 .upload-content {
   display: grid;
-  gap: var(--space-xs);
+  gap: var(--space-sm);
   cursor: pointer;
 }
 
-.upload-content h3 {
-  font-size: var(--text-lg);
+.upload-placeholder {
+  display: grid;
+  gap: var(--space-xs);
+  place-items: center;
+  color: var(--theme-text);
 }
 
-.upload-content p {
-  color: var(--theme-text-muted);
-  font-size: var(--text-sm);
-}
-
-.upload-icon {
-  font-size: 2.5rem;
+.upload-placeholder i {
+  font-size: 2.75rem;
   color: var(--theme-primary);
+}
+
+.upload-placeholder p {
+  font-size: var(--text-md);
+  font-weight: 600;
 }
 
 .upload-button {
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  margin-inline: auto;
-  padding: 0.6rem var(--space-md);
-  border-radius: var(--radius-pill);
+  padding: 0.65rem var(--space-lg);
+  border-radius: 14px;
   background: var(--theme-primary);
   color: var(--theme-secondary);
-  font-weight: 600;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .analysis-results,
@@ -62,9 +67,9 @@
   display: grid;
   gap: var(--space-sm);
   padding: var(--space-md);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--theme-border);
-  background: rgba(255, 255, 255, 0.03);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
 }
 
 @media (min-width: 64rem) {

--- a/styles/components/forms.css
+++ b/styles/components/forms.css
@@ -60,8 +60,8 @@ textarea {
 
 .prompt-settings {
   display: grid;
-  gap: var(--space-xs);
-  margin-block: var(--space-md);
+  gap: var(--space-md);
+  margin-block: var(--space-lg);
 }
 
 .prompt-settings input[type='range'] {
@@ -93,16 +93,27 @@ textarea {
 
 .prompt-editor {
   display: grid;
+  gap: var(--space-sm);
+}
+
+.prompt-textarea__wrapper {
+  position: relative;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  padding: var(--space-sm);
 }
 
 .prompt-textarea {
   font-family: var(--font-mono);
-  line-height: 1.5;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--theme-border);
-  border-radius: var(--radius-lg);
-  padding: var(--space-md);
+  line-height: 1.6;
+  background: transparent;
+  border: none;
   color: var(--theme-text);
+  width: 100%;
+  min-height: 220px;
+  padding: var(--space-sm) var(--space-md) var(--space-lg);
+  resize: vertical;
 }
 
 .prompt-textarea::placeholder {
@@ -110,8 +121,7 @@ textarea {
 }
 
 .prompt-textarea:focus {
-  border-color: var(--theme-primary);
-  box-shadow: 0 0 0 4px rgba(0, 255, 136, 0.15);
+  outline: none;
 }
 
 .upload-guidance {
@@ -132,3 +142,209 @@ textarea {
   }
 }
 
+
+.range-field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.range-field__label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+}
+
+.range-value {
+  color: var(--theme-text-muted);
+}
+
+.segment-card {
+  display: grid;
+  gap: var(--space-sm);
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: var(--space-sm);
+}
+
+.segment-card__label {
+  font-weight: 600;
+  color: var(--theme-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.segmented-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+  gap: 0.5rem;
+}
+
+.segment {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: transparent;
+  color: var(--theme-text-muted);
+  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
+}
+
+.segment:hover,
+.segment:focus-visible {
+  color: #ffffff;
+}
+
+.segment.is-active {
+  background: var(--theme-primary);
+  color: var(--theme-secondary);
+  transform: translateY(-1px);
+  border-color: transparent;
+}
+
+.clear-field {
+  position: absolute;
+  top: 0.75rem;
+  inset-inline-end: 0.75rem;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--theme-text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.clear-field:hover,
+.clear-field:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+}
+
+.char-counter {
+  position: absolute;
+  bottom: 0.65rem;
+  inset-inline-end: 1rem;
+  font-size: 0.75rem;
+  color: var(--theme-text-muted);
+}
+
+.enhance-toggle {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--theme-text-muted);
+}
+
+.toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.toggle__indicator {
+  position: relative;
+  width: 48px;
+  height: 26px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  transition: background var(--transition-fast);
+}
+
+.toggle__indicator::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  inset-inline-start: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #ffffff;
+  transition: transform var(--transition-fast);
+}
+
+.toggle__label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--theme-text);
+}
+
+.toggle input:checked + .toggle__indicator {
+  background: var(--theme-primary);
+}
+
+.toggle input:checked + .toggle__indicator::after {
+  transform: translateX(22px);
+}
+
+.description-card {
+  margin-top: var(--space-lg);
+  display: grid;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.description-card__header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.description-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.description-option {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.02);
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--theme-text);
+  text-align: left;
+  transition: background var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.description-option:hover,
+.description-option:focus-visible {
+  border-color: var(--theme-primary);
+  transform: translateY(-1px);
+}
+
+.description-option.is-active {
+  background: rgba(29, 185, 84, 0.15);
+  border-color: var(--theme-primary);
+  color: #ffffff;
+}
+
+.custom-question {
+  display: grid;
+  gap: var(--space-xs);
+}
+
+@media (max-width: 40rem) {
+  .description-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/styles/components/panels.css
+++ b/styles/components/panels.css
@@ -1,8 +1,8 @@
 /* Specialized panels and layout components */
 
 .prompt-preview {
-  border-radius: var(--radius-md);
-  border: 1px solid var(--theme-border);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.03);
   padding: var(--space-md);
   min-height: 160px;
@@ -27,9 +27,9 @@
   display: grid;
   gap: var(--space-2xs);
   padding-inline: var(--space-sm);
-  padding-block: 0.4rem;
-  border-radius: var(--radius-pill);
-  border: 1px solid var(--theme-border);
+  padding-block: 0.45rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.03);
   min-width: 100px;
   text-align: center;
@@ -91,46 +91,29 @@
 
 .hf-embed {
   margin-top: var(--space-lg);
-  border-radius: var(--radius-lg);
+  border-radius: 20px;
   overflow: hidden;
-  border: 1px solid var(--theme-border);
-  box-shadow: var(--shadow-sm);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 55px rgba(0, 0, 0, 0.45);
 }
 
 .mini-frame {
   width: 100%;
   border: none;
   min-height: 60vh;
-  border-radius: var(--radius-lg);
-  background: var(--theme-surface);
+  border-radius: 20px;
+  background: rgba(24, 24, 24, 0.85);
 }
 
 @media (min-width: 48rem) {
   .action-toolbar {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    align-items: start;
-  }
-
-  .action-toolbar > *:not(.more-actions) {
-    grid-column: span 1;
-  }
-
-  .copy-action {
-    grid-row: 1 / span 2;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (min-width: 64rem) {
   .action-toolbar {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .action-toolbar > * {
-    width: auto;
-  }
-
-  .copy-action {
-    grid-row: auto;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 

--- a/styles/components/tabs.css
+++ b/styles/components/tabs.css
@@ -1,15 +1,17 @@
 /* Tab navigation styling */
 
 .tabs {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: calc(var(--z-header) - 10);
   display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: 1fr;
-  gap: var(--space-xs);
-  background: var(--theme-surface);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--theme-border);
-  padding: var(--space-2xs);
-  overflow: hidden;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.25rem;
+  padding: 0.5rem clamp(1rem, 4vw, 2rem);
+  background: rgba(12, 12, 12, 0.95);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(18px);
 }
 
 .tab {
@@ -17,29 +19,44 @@
   background: transparent;
   color: var(--theme-text-muted);
   font-weight: 600;
-  padding: var(--space-sm);
-  border-radius: var(--radius-md);
-  min-height: 44px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.5rem;
+  min-height: 52px;
+  border-radius: 14px;
   display: inline-flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: var(--space-2xs);
-  transition: background var(--transition-fast), color var(--transition-fast);
+  gap: 0.35rem;
+  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
 }
 
-.tab.active,
+.tab i {
+  font-size: 1.2rem;
+}
+
+.tab span {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+}
+
+.tab.active {
+  background: var(--accent-blue);
+  color: #ffffff;
+  transform: translateY(-2px);
+}
+
 .tab:hover {
-  background: var(--theme-primary);
-  color: var(--theme-secondary);
+  color: #ffffff;
 }
 
 .tab-content {
   display: none;
-  background: var(--theme-surface);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--theme-border);
-  padding: clamp(var(--space-md), 2vw, var(--space-xl));
-  box-shadow: var(--shadow-sm);
+  background: transparent;
+  border: none;
+  padding: 0;
+  box-shadow: none;
 }
 
 .tab-content.active {
@@ -48,7 +65,9 @@
 
 .prompt-workspace,
 .batch-section,
-.image-upload-area {
+.image-prompt-grid,
+.embed-card,
+.actions-card {
   display: grid;
   gap: var(--space-lg);
 }
@@ -57,7 +76,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-sm);
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
 }
 
@@ -67,10 +86,4 @@
   gap: var(--space-xs);
 }
 
-@media (max-width: 30rem) {
-  .tabs {
-    grid-auto-flow: row;
-    grid-auto-columns: unset;
-  }
-}
 

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -25,10 +25,10 @@
   align-items: center;
   justify-content: space-between;
   padding-block: var(--space-sm);
-  padding-inline: var(--app-padding-inline);
-  background: var(--theme-surface, var(--theme-secondary));
-  border-bottom: 1px solid var(--theme-border);
-  backdrop-filter: blur(12px);
+  padding-inline: clamp(1rem, 4vw, 2.5rem);
+  background: linear-gradient(135deg, var(--theme-primary), #22c96a);
+  color: var(--theme-secondary);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
 }
 
 .app-header__start {
@@ -40,19 +40,38 @@
 .app-brand {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2xs);
+  gap: 0.25rem;
+}
+
+.app-brand__badge {
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .app-title {
+  font-size: clamp(1.25rem, 1.1rem + 1vw, 1.75rem);
+  font-weight: 700;
+  color: inherit;
+}
+
+.app-header__actions {
   display: flex;
   align-items: center;
   gap: var(--space-xs);
 }
 
-.app-header__end {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
+.app-header .icon-button {
+  border-color: rgba(255, 255, 255, 0.25);
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--theme-secondary);
+}
+
+.app-header .icon-button:hover,
+.app-header .icon-button:focus-visible {
+  background: rgba(0, 0, 0, 0.28);
+  color: #ffffff;
 }
 
 .header-actions {
@@ -61,37 +80,38 @@
 }
 
 .app-shell {
-  width: min(100%, var(--content-max-width));
+  width: min(100%, 1280px);
   margin-inline: auto;
-  padding-inline: var(--app-padding-inline);
-  padding-block: var(--space-lg);
+  padding-inline: clamp(1rem, 5vw, 3rem);
+  padding-block: var(--space-xl) calc(var(--space-xl) + 96px);
   display: grid;
-  gap: var(--space-lg);
+  gap: var(--space-xl);
 }
 
 .control-strip {
   display: grid;
   grid-template-columns: 1fr;
-  gap: var(--space-sm);
-  padding: var(--space-sm);
-  border-radius: var(--radius-lg);
-  background: var(--theme-surface);
+  gap: var(--space-md);
+  padding: var(--space-lg);
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(36, 36, 36, 0.9), rgba(18, 18, 18, 0.95));
   border: 1px solid var(--theme-border);
-  box-shadow: var(--shadow-sm);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
   position: relative;
 }
 
 .control-strip__pill {
   position: absolute;
-  top: -0.8rem;
-  inset-inline-start: var(--space-sm);
-  background: var(--theme-primary);
-  color: var(--theme-secondary);
-  padding: 0.25rem var(--space-sm);
+  top: -0.9rem;
+  inset-inline-start: var(--space-lg);
+  background: var(--theme-accent);
+  color: #ffffff;
+  padding: 0.35rem var(--space-sm);
   border-radius: var(--radius-pill);
   font-size: var(--text-sm);
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .control-strip__group,
@@ -228,13 +248,6 @@
   .control-strip {
     grid-template-columns: auto minmax(0, 280px) 1fr auto;
     align-items: center;
-  }
-
-  .control-strip__pill {
-    position: static;
-    background: transparent;
-    color: var(--theme-text-muted);
-    padding: 0;
   }
 
   .app-secondary {


### PR DESCRIPTION
## Summary
- redesign the prompt builder layout with a green-accented dark theme, sticky header, and new bottom navigation
- restyle core feature sections into responsive cards, add segmented aspect ratio controls, magic enhance toggle, and mobile friendly upload grid
- enhance image-to-prompt workflow with description presets, custom question support, and copy button while updating actions into a More Tools workspace

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68c9ccd11f948329b297dfe6a0b10531