### PR TITLE
Refine layout and tools for streamlined prompt workspace

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,59 +19,22 @@
     <link rel="stylesheet" href="styles/components/panels.css">
     <link rel="stylesheet" href="styles/components/dropzone.css">
     <link rel="stylesheet" href="styles/components/modal.css">
-    <link rel="stylesheet" href="styles/components/drawer.css">
 </head>
 <body data-theme="cyberpunk_neon">
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
     <header class="app-header" role="banner">
         <div class="app-header__start">
-            <button class="icon-button" id="menu-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-drawer">
-                <span class="hamburger-icon" aria-hidden="true"></span>
-                <span class="visually-hidden">Toggle navigation</span>
-            </button>
             <div class="app-brand">
                 <span class="app-brand__badge">AI Prompt Suite</span>
                 <h1 class="app-title">AI Prompt Generator</h1>
             </div>
         </div>
-        <div class="app-header__actions">
-            <button class="icon-button" type="button" id="header-help" aria-label="Open help center" data-modal-open="help-modal">
-                <i class="fas fa-circle-info" aria-hidden="true"></i>
-            </button>
-        </div>
     </header>
-
-    <aside class="drawer" id="mobile-drawer" aria-hidden="true" aria-labelledby="mobile-drawer-title">
-        <div class="drawer__content">
-            <header class="drawer__header">
-                <h2 id="mobile-drawer-title">Menu</h2>
-                <button class="icon-button" type="button" id="drawer-close" aria-label="Close menu">
-                    <span class="icon-button__label">Close</span>
-                    <i class="fas fa-times" aria-hidden="true"></i>
-                </button>
-            </header>
-            <nav class="drawer__nav" aria-label="Primary">
-                <button class="drawer__link" data-drawer-tab="prompt-builder" type="button"><i class="fas fa-pen" aria-hidden="true"></i> Prompt Builder</button>
-                <button class="drawer__link" data-drawer-tab="image-to-prompt" type="button"><i class="fas fa-image" aria-hidden="true"></i> Image to Prompt</button>
-                <button class="drawer__link" data-drawer-tab="image-generator" type="button"><i class="fas fa-wand-magic-sparkles" aria-hidden="true"></i> Image Generator</button>
-                <button class="drawer__link" data-drawer-tab="more-tools" type="button"><i class="fas fa-toolbox" aria-hidden="true"></i> More Tools</button>
-            </nav>
-            <div class="drawer__actions">
-                <button class="btn btn--secondary btn--full-width" type="button" data-drawer-collaborate>
-                    <i class="fas fa-share-nodes" aria-hidden="true"></i> Share Prompt
-                </button>
-                <button class="btn btn--outline btn--full-width" type="button" data-drawer-mini>
-                    <i class="fas fa-bolt" aria-hidden="true"></i> Quick Generator
-                </button>
-            </div>
-        </div>
-    </aside>
-    <div class="scrim" id="scrim" hidden></div>
 
     <div class="app-shell">
         <section class="control-strip" aria-label="Workspace controls">
-            <span class="control-strip__pill" aria-hidden="true">Advanced</span>
+            <span class="control-strip__pill" aria-hidden="true">Workspace</span>
             <div class="control-strip__group control-strip__group--platform">
                 <label class="control-strip__label" for="platform-select"><i class="fas fa-cogs" aria-hidden="true"></i> Platform</label>
                 <div class="select-field">
@@ -85,36 +48,26 @@
                 </div>
             </div>
             <div class="control-strip__group control-strip__group--themes">
-                <span class="control-strip__label"><i class="fas fa-palette" aria-hidden="true"></i> Quick Themes</span>
-                <div class="chip-carousel" role="listbox" aria-label="Theme selection">
-                    <button class="chip theme-chip is-active" type="button" role="option" aria-selected="true" data-theme="cyberpunk_neon">Cyberpunk</button>
-                    <button class="chip theme-chip" type="button" role="option" aria-selected="false" data-theme="dark_professional">Dark</button>
-                    <button class="chip theme-chip" type="button" role="option" aria-selected="false" data-theme="light_modern">Light</button>
-                    <button class="chip theme-chip" type="button" role="option" aria-selected="false" data-theme="warm_autumn">Autumn</button>
-                    <button class="chip theme-chip" type="button" role="option" aria-selected="false" data-theme="ocean_blue">Ocean</button>
-                    <button class="chip theme-chip" type="button" role="option" aria-selected="false" data-theme="pastel_dreams">Pastel</button>
-                    <button class="chip theme-chip" type="button" role="option" aria-selected="false" data-theme="forest_green">Forest</button>
-                    <button class="chip theme-chip" type="button" role="option" aria-selected="false" data-theme="sunset_gradient">Sunset</button>
+                <span class="control-strip__label"><i class="fas fa-palette" aria-hidden="true"></i> Theme Presets</span>
+                <div class="theme-dial" role="radiogroup" aria-label="Theme presets">
+                    <button class="theme-swatch is-active" type="button" role="radio" aria-checked="true" data-theme="cyberpunk_neon" data-theme-mode="dark">
+                        <span class="theme-swatch__dot" aria-hidden="true"></span>
+                        <span class="theme-swatch__label">Neon</span>
+                    </button>
+                    <button class="theme-swatch" type="button" role="radio" aria-checked="false" data-theme="dark_professional" data-theme-mode="dark">
+                        <span class="theme-swatch__dot" aria-hidden="true"></span>
+                        <span class="theme-swatch__label">Midnight</span>
+                    </button>
+                    <button class="theme-swatch" type="button" role="radio" aria-checked="false" data-theme="light_modern" data-theme-mode="light">
+                        <span class="theme-swatch__dot" aria-hidden="true"></span>
+                        <span class="theme-swatch__label">Daylight</span>
+                    </button>
+                    <button class="theme-swatch" type="button" role="radio" aria-checked="false" data-theme="pastel_dreams" data-theme-mode="light">
+                        <span class="theme-swatch__dot" aria-hidden="true"></span>
+                        <span class="theme-swatch__label">Breeze</span>
+                    </button>
                 </div>
-                <label class="visually-hidden" for="theme-select">Theme</label>
-                <select id="theme-select" class="visually-hidden">
-                    <option value="cyberpunk_neon" selected>Cyberpunk Neon</option>
-                    <option value="dark_professional">Dark Professional</option>
-                    <option value="light_modern">Light Modern</option>
-                    <option value="warm_autumn">Warm Autumn</option>
-                    <option value="ocean_blue">Ocean Blue</option>
-                    <option value="pastel_dreams">Pastel Dreams</option>
-                    <option value="forest_green">Forest Green</option>
-                    <option value="sunset_gradient">Sunset Gradient</option>
-                </select>
-            </div>
-            <div class="control-strip__actions">
-                <button class="btn btn--outline btn--compact" type="button" id="collaboration-btn">
-                    <i class="fas fa-share-nodes" aria-hidden="true"></i> Share
-                </button>
-                <a class="btn btn--outline btn--compact" id="mini-generator-link" href="#" data-header-mini>
-                    <i class="fas fa-bolt" aria-hidden="true"></i> Quick Gen
-                </a>
+                <p class="control-strip__helper" id="theme-mode-indicator" aria-live="polite">Dark mode • Neon</p>
             </div>
         </section>
 
@@ -132,7 +85,7 @@
                     </header>
                     <div class="quick-actions__buttons" role="group" aria-label="Prompt generation shortcuts">
                         <div class="quick-actions__item">
-                            <button class="quick-action" type="button" data-tab-target="prompt-builder" data-focus-target="#prompt-textarea" data-tooltip="Open the prompt builder workspace" data-tooltip-base="Open the prompt builder workspace">
+                            <button class="quick-action" type="button" data-tab-target="prompt-builder" data-focus-target="#prompt-textarea">
                                 <span class="quick-action__icon" aria-hidden="true"><i class="fas fa-pen-nib"></i></span>
                                 <span class="quick-action__content">
                                     <span class="quick-action__label">Generate Prompt</span>
@@ -142,7 +95,7 @@
                             </button>
                         </div>
                         <div class="quick-actions__item">
-                            <button class="quick-action" type="button" data-tab-target="more-tools" data-focus-target="#batch-base-prompt" data-scroll-target="#batch-base-prompt" data-tooltip="Open the batch generator for rapid variations" data-tooltip-base="Open the batch generator for rapid variations">
+                            <button class="quick-action" type="button" data-tab-target="more-tools" data-focus-target="#batch-base-prompt" data-scroll-target="#batch-base-prompt">
                                 <span class="quick-action__icon" aria-hidden="true"><i class="fas fa-layer-group"></i></span>
                                 <span class="quick-action__content">
                                     <span class="quick-action__label">Batch Prompt Generator</span>
@@ -152,7 +105,7 @@
                             </button>
                         </div>
                         <div class="quick-actions__item">
-                            <button class="quick-action" type="button" data-tab-target="more-tools" data-focus-target="#batch-results" data-scroll-target="#batch-results" data-tooltip="Review your prompt experiments side-by-side" data-tooltip-base="Review your prompt experiments side-by-side">
+                            <button class="quick-action" type="button" data-tab-target="more-tools" data-focus-target="#batch-results" data-scroll-target="#batch-results">
                                 <span class="quick-action__icon" aria-hidden="true"><i class="fas fa-vials"></i></span>
                                 <span class="quick-action__content">
                                     <span class="quick-action__label">A/B Testing Lab</span>
@@ -170,7 +123,7 @@
                     </header>
                     <div class="quick-actions__buttons" role="group" aria-label="Image workflow shortcuts">
                         <div class="quick-actions__item">
-                            <button class="quick-action" type="button" data-tab-target="image-to-prompt" data-focus-target="#image-upload" data-scroll-target="#image-upload" data-tooltip="Upload an image for instant analysis" data-tooltip-base="Upload an image for instant analysis">
+                            <button class="quick-action" type="button" data-tab-target="image-to-prompt" data-focus-target="#image-upload" data-scroll-target="#image-upload">
                                 <span class="quick-action__icon" aria-hidden="true"><i class="fas fa-upload"></i></span>
                                 <span class="quick-action__content">
                                     <span class="quick-action__label">Upload Image</span>
@@ -180,7 +133,7 @@
                             </button>
                         </div>
                         <div class="quick-actions__item">
-                            <button class="quick-action" type="button" data-tab-target="image-to-prompt" data-focus-target="#hf-image-to-prompt-container" data-scroll-target="#hf-image-to-prompt-container" data-tooltip="Launch the image-to-prompt converter" data-tooltip-base="Launch the image-to-prompt converter">
+                            <button class="quick-action" type="button" data-tab-target="image-to-prompt" data-focus-target="#hf-image-to-prompt-container" data-scroll-target="#hf-image-to-prompt-container">
                                 <span class="quick-action__icon" aria-hidden="true"><i class="fas fa-image"></i></span>
                                 <span class="quick-action__content">
                                     <span class="quick-action__label">Image to Prompt</span>
@@ -193,23 +146,12 @@
                 </article>
                 <article class="quick-actions__group" aria-labelledby="quick-actions-preferences">
                     <header class="quick-actions__header">
-                        <h3 id="quick-actions-preferences">Settings &amp; Preferences</h3>
-                        <p>Personalise the workspace so it matches your creative flow.</p>
+                        <h3 id="quick-actions-preferences">Personalise</h3>
+                        <p>Adjust helper text and copy preferences from one place.</p>
                     </header>
                     <div class="quick-actions__buttons" role="group" aria-label="Preference shortcuts">
                         <div class="quick-actions__item">
-                            <button class="quick-action" type="button" data-action="toggle-theme" data-tooltip="Switch between light and dark workspaces" data-tooltip-base="Switch between light and dark workspaces">
-                                <span class="quick-action__icon" aria-hidden="true"><i class="fas fa-moon" data-theme-icon></i></span>
-                                <span class="quick-action__content">
-                                    <span class="quick-action__label">Theme Toggle</span>
-                                    <span class="quick-action__description">Toggle the interface between bright focus mode and dark studio mode.</span>
-                                    <span class="quick-action__status" data-theme-label aria-live="polite"></span>
-                                </span>
-                                <span class="quick-action__loader" aria-hidden="true"><i class="fas fa-spinner fa-spin"></i></span>
-                            </button>
-                        </div>
-                        <div class="quick-actions__item">
-                            <button class="quick-action" type="button" data-action="open-language" aria-expanded="false" aria-controls="language-preferences-panel" data-tooltip="Adjust interface language" data-tooltip-base="Adjust interface language">
+                            <button class="quick-action" type="button" data-action="open-language" aria-expanded="false" aria-controls="language-preferences-panel">
                                 <span class="quick-action__icon" aria-hidden="true"><i class="fas fa-language"></i></span>
                                 <span class="quick-action__content">
                                     <span class="quick-action__label">Language Preferences</span>
@@ -239,7 +181,7 @@
                     </header>
                     <div class="quick-actions__buttons" role="group" aria-label="Help shortcuts">
                         <div class="quick-actions__item">
-                            <button class="quick-action" type="button" data-open-modal="help-modal" data-tooltip="Browse tutorials and workflow tips" data-tooltip-base="Browse tutorials and workflow tips">
+                            <button class="quick-action" type="button" data-open-modal="help-modal">
                                 <span class="quick-action__icon" aria-hidden="true"><i class="fas fa-life-ring"></i></span>
                                 <span class="quick-action__content">
                                     <span class="quick-action__label">Help Center</span>
@@ -249,7 +191,7 @@
                             </button>
                         </div>
                         <div class="quick-actions__item">
-                            <button class="quick-action" type="button" data-open-url="privacy.html" data-open-target="_blank" data-tooltip="Review how we protect your uploads" data-tooltip-base="Review how we protect your uploads">
+                            <button class="quick-action" type="button" data-open-url="privacy.html" data-open-target="_blank">
                                 <span class="quick-action__icon" aria-hidden="true"><i class="fas fa-shield-heart"></i></span>
                                 <span class="quick-action__content">
                                     <span class="quick-action__label">Privacy Policy</span>
@@ -259,7 +201,7 @@
                             </button>
                         </div>
                         <div class="quick-actions__item">
-                            <button class="quick-action" type="button" data-open-url="mailto:hello@rajuprompter.app" data-tooltip="Send us feedback or feature requests" data-tooltip-base="Send us feedback or feature requests">
+                            <button class="quick-action" type="button" data-open-url="mailto:hello@rajuprompter.app">
                                 <span class="quick-action__icon" aria-hidden="true"><i class="fas fa-envelope-open-text"></i></span>
                                 <span class="quick-action__content">
                                     <span class="quick-action__label">Contact Support</span>
@@ -275,94 +217,7 @@
 
         <main id="main-content" class="app-main-area" tabindex="-1">
             <div class="app-grid">
-                <aside class="app-sidebar sidebar" aria-label="Creative assist panels">
-                    <details class="panel panel--disclosure" id="ai-suggestions-panel" data-breakpoint="md">
-                        <summary class="panel__summary">
-                            <span class="panel__title"><i class="fas fa-robot" aria-hidden="true"></i> AI Suggestions</span>
-                            <i class="fas fa-chevron-down" aria-hidden="true"></i>
-                        </summary>
-                        <div class="panel__body">
-                            <div class="ai-suggestions" id="ai-suggestions">
-                                <div class="suggestion-item">
-                                    <i class="fas fa-lightbulb" aria-hidden="true"></i>
-                                    <span>Add lighting description for better mood</span>
-                                </div>
-                            </div>
-                            <button class="btn btn--sm btn--secondary btn--full-width" id="get-suggestions" type="button">
-                                <i class="fas fa-magic" aria-hidden="true"></i> Get AI Suggestions
-                            </button>
-                        </div>
-                    </details>
-
-                    <section class="panel" aria-labelledby="random-generator-heading">
-                        <div class="panel__header">
-                            <h3 id="random-generator-heading"><i class="fas fa-dice" aria-hidden="true"></i> Random Generators</h3>
-                        </div>
-                        <div class="panel__body">
-                            <div class="random-buttons">
-                                <button class="random-btn" data-category="portrait" type="button">
-                                    <span class="icon" aria-hidden="true">👤</span>
-                                    <span>Portrait</span>
-                                </button>
-                                <button class="random-btn" data-category="landscape" type="button">
-                                    <span class="icon" aria-hidden="true">🌄</span>
-                                    <span>Landscape</span>
-                                </button>
-                                <button class="random-btn" data-category="digital_art" type="button">
-                                    <span class="icon" aria-hidden="true">🎨</span>
-                                    <span>Digital Art</span>
-                                </button>
-                                <button class="random-btn" data-category="photography" type="button">
-                                    <span class="icon" aria-hidden="true">📸</span>
-                                    <span>Photography</span>
-                                </button>
-                                <button class="random-btn" data-category="fantasy" type="button">
-                                    <span class="icon" aria-hidden="true">🐉</span>
-                                    <span>Fantasy</span>
-                                </button>
-                                <button class="random-btn" data-category="surprise" type="button">
-                                    <span class="icon" aria-hidden="true">🎲</span>
-                                    <span>Surprise Me</span>
-                                </button>
-                            </div>
-                        </div>
-                    </section>
-
-                    <section class="panel word-library" aria-labelledby="word-library-heading">
-                        <div class="panel__header">
-                            <h3 id="word-library-heading"><i class="fas fa-book" aria-hidden="true"></i> Smart Word Library</h3>
-                        </div>
-                        <div class="panel__body">
-                            <div class="word-search">
-                                <label class="visually-hidden" for="word-search">Search words</label>
-                                <input type="text" id="word-search" class="form-control" placeholder="Search 3000+ words...">
-                                <i class="fas fa-search search-icon" aria-hidden="true"></i>
-                            </div>
-                            <div class="category-tabs" role="tablist" aria-label="Word library categories">
-                                <button class="category-tab active" role="tab" aria-selected="true" data-category="subjects">Subjects</button>
-                                <button class="category-tab" role="tab" aria-selected="false" data-category="styles">Styles</button>
-                                <button class="category-tab" role="tab" aria-selected="false" data-category="lighting">Lighting</button>
-                                <button class="category-tab" role="tab" aria-selected="false" data-category="colors">Colors</button>
-                                <button class="category-tab" role="tab" aria-selected="false" data-category="composition">Composition</button>
-                                <button class="category-tab" role="tab" aria-selected="false" data-category="moods">Moods</button>
-                            </div>
-                            <div class="word-bank" id="word-bank" aria-live="polite">
-                                <!-- Words populated by JavaScript -->
-                            </div>
-                        </div>
-                    </section>
-
-                    <section class="panel" aria-labelledby="recent-prompts-heading">
-                        <div class="panel__header">
-                            <h3 id="recent-prompts-heading"><i class="fas fa-history" aria-hidden="true"></i> Recent Prompts</h3>
-                        </div>
-                        <div class="panel__body">
-                            <div class="prompt-history" id="prompt-history" aria-live="polite">
-                                <!-- History populated by JavaScript -->
-                            </div>
-                        </div>
-                    </section>
-                </aside>
+                
 
                 <section class="app-main main-content" aria-label="Prompt builder">
                     <section class="tab-content active" id="prompt-builder-tab" role="tabpanel" aria-labelledby="tab-prompt-builder" tabindex="0">
@@ -378,9 +233,6 @@
                                     </button>
                                     <button class="btn btn--sm btn--outline" id="optimize-prompt" type="button">
                                         <i class="fas fa-wand-magic-sparkles" aria-hidden="true"></i> Enhance Now
-                                    </button>
-                                    <button class="btn btn--sm btn--secondary" id="voice-input" type="button">
-                                        <i class="fas fa-microphone" aria-hidden="true"></i> Voice Input
                                     </button>
                                 </div>
                             </header>
@@ -429,12 +281,37 @@
                                 </div>
                                 <div class="editor-status" aria-live="polite">
                                     <span class="status-pill" id="word-count">0 words</span>
-                                    <span class="status-pill" id="quality-indicator">Quality: GOOD (65%)</span>
+                                    <span class="status-pill" id="quality-indicator">Quality: 0%</span>
                                     <span class="status-pill status-pill--accent" id="platform-compatibility">
                                         <i class="fas fa-check-circle" aria-hidden="true"></i> Platform Optimized
                                     </span>
                                 </div>
                             </div>
+
+                            <section class="word-library-card" aria-labelledby="word-library-heading">
+                                <header class="word-library-card__header">
+                                    <h3 id="word-library-heading"><i class="fas fa-book" aria-hidden="true"></i> Smart Word Library</h3>
+                                    <p>Tap any word to add it to your prompt without leaving the editor.</p>
+                                </header>
+                                <div class="word-library-card__controls">
+                                    <label class="visually-hidden" for="word-search">Search words</label>
+                                    <div class="word-library-card__search">
+                                        <i class="fas fa-search" aria-hidden="true"></i>
+                                        <input type="text" id="word-search" class="form-control" placeholder="Search 3000+ words...">
+                                    </div>
+                                    <div class="category-tabs" role="tablist" aria-label="Word library categories">
+                                        <button class="category-tab active" role="tab" aria-selected="true" data-category="subjects">Subjects</button>
+                                        <button class="category-tab" role="tab" aria-selected="false" data-category="styles">Styles</button>
+                                        <button class="category-tab" role="tab" aria-selected="false" data-category="lighting">Lighting</button>
+                                        <button class="category-tab" role="tab" aria-selected="false" data-category="colors">Colors</button>
+                                        <button class="category-tab" role="tab" aria-selected="false" data-category="composition">Composition</button>
+                                        <button class="category-tab" role="tab" aria-selected="false" data-category="moods">Moods</button>
+                                    </div>
+                                </div>
+                                <div class="word-bank" id="word-bank" aria-live="polite">
+                                    <!-- Words populated by JavaScript -->
+                                </div>
+                            </section>
 
                             <div class="platform-specific-controls" id="platform-controls">
                                 <!-- Controls populated dynamically based on platform -->
@@ -538,10 +415,10 @@
                         <article class="embed-card">
                             <header class="card-header">
                                 <p class="workspace-eyebrow">Quick Ideas</p>
-                                <h2>Image Prompt Generator</h2>
-                                <p class="card-subtitle">Use the lightweight generator for rapid inspiration.</p>
+                                <h2>Chota Dhamaka</h2>
+                                <p class="card-subtitle">Launch the playful mini studio for instant visual prompts.</p>
                             </header>
-                            <iframe data-deferred-tab="image-generator" data-src="classicpg/index.html" class="mini-frame" title="Quick image prompt generator" loading="lazy"></iframe>
+                            <iframe data-deferred-tab="image-generator" data-src="classicpg/index.html" class="mini-frame" title="Chota Dhamaka mini generator" loading="lazy"></iframe>
                         </article>
                     </section>
 
@@ -593,32 +470,53 @@
                             <article class="actions-card">
                                 <header class="card-header">
                                     <p class="workspace-eyebrow">Prompt Actions</p>
-                                    <h2>Manage &amp; Share</h2>
+                                    <h2>Quick Actions</h2>
                                 </header>
                                 <div class="action-toolbar" role="group" aria-label="Prompt actions">
-                                    <div class="copy-action">
-                                        <button class="btn btn--secondary" id="copy-prompt" type="button">
-                                            <i class="fas fa-copy" aria-hidden="true"></i> Copy Prompt
-                                        </button>
-                                        <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>
-                                    </div>
+                                    <button class="btn btn--secondary" id="copy-prompt" type="button">
+                                        <i class="fas fa-copy" aria-hidden="true"></i> Copy Prompt
+                                    </button>
                                     <button class="btn btn--primary" id="save-prompt" type="button">
                                         <i class="fas fa-save" aria-hidden="true"></i> Save Prompt
                                     </button>
-                                    <button class="btn btn--outline" type="button" data-header-collaborate>
-                                        <i class="fas fa-share-nodes" aria-hidden="true"></i> Share Prompt
+                                </div>
+                                <p class="status-message" id="action-feedback" role="status" aria-live="polite"></p>
+                            </article>
+
+                            <article class="helper-card">
+                                <header class="card-header">
+                                    <p class="workspace-eyebrow">Workflow Helpers</p>
+                                    <h2>Inspiration &amp; History</h2>
+                                </header>
+                                <div class="random-buttons" role="group" aria-label="Random prompt generators">
+                                    <button class="random-btn" data-category="portrait" type="button">
+                                        <span class="icon" aria-hidden="true">👤</span>
+                                        <span>Portrait</span>
                                     </button>
-                                    <button class="btn btn--outline" type="button" data-header-mini>
-                                        <i class="fas fa-bolt" aria-hidden="true"></i> Quick Generator
+                                    <button class="random-btn" data-category="landscape" type="button">
+                                        <span class="icon" aria-hidden="true">🌄</span>
+                                        <span>Landscape</span>
                                     </button>
-                                    <button class="btn btn--outline" id="export-txt" type="button">
-                                        <i class="fas fa-file-export" aria-hidden="true"></i> Export .txt
+                                    <button class="random-btn" data-category="digital_art" type="button">
+                                        <span class="icon" aria-hidden="true">🎨</span>
+                                        <span>Digital Art</span>
                                     </button>
-                                    <button class="btn btn--outline" id="share-prompt" type="button">
-                                        <i class="fas fa-share-alt" aria-hidden="true"></i> Share Link
+                                    <button class="random-btn" data-category="photography" type="button">
+                                        <span class="icon" aria-hidden="true">📸</span>
+                                        <span>Photography</span>
                                     </button>
-                                    <button class="btn btn--outline" id="analyze-prompt" type="button">
-                                        <i class="fas fa-chart-line" aria-hidden="true"></i> Deep Analysis
+                                    <button class="random-btn" data-category="fantasy" type="button">
+                                        <span class="icon" aria-hidden="true">🐉</span>
+                                        <span>Fantasy</span>
+                                    </button>
+                                    <button class="random-btn" data-category="surprise" type="button">
+                                        <span class="icon" aria-hidden="true">🎲</span>
+                                        <span>Surprise Me</span>
+                                    </button>
+                                </div>
+                                <div class="helper-actions">
+                                    <button class="btn btn--outline btn--full-width" type="button" data-modal-open="recent-prompts-modal" id="open-recent-prompts">
+                                        <i class="fas fa-history" aria-hidden="true"></i> View Recent Prompts
                                     </button>
                                 </div>
                             </article>
@@ -645,7 +543,7 @@
                                 </div>
                                 <div class="metric">
                                     <span class="metric-label">Quality</span>
-                                    <span class="metric-value quality-score" id="quality-score">85%</span>
+                                    <span class="metric-value quality-score" id="quality-score">0%</span>
                                 </div>
                                 <div class="metric">
                                     <span class="metric-label">Tokens</span>
@@ -654,17 +552,6 @@
                             </div>
                         </div>
                     </details>
-
-                    <section class="panel" aria-labelledby="advanced-settings-heading">
-                        <div class="panel__header">
-                            <h3 id="advanced-settings-heading"><i class="fas fa-sliders-h" aria-hidden="true"></i> Advanced Settings</h3>
-                        </div>
-                        <div class="panel__body">
-                            <div class="advanced-settings" id="advanced-settings">
-                                <!-- Platform-specific controls populated by JavaScript -->
-                            </div>
-                        </div>
-                    </section>
 
                     <section class="panel" aria-labelledby="saved-prompts-heading">
                         <div class="panel__header">
@@ -704,7 +591,7 @@
         </button>
         <button class="tab" id="tab-image-generator" data-tab="image-generator" role="tab" aria-selected="false" aria-controls="image-generator-tab">
             <i class="fas fa-wand-magic-sparkles" aria-hidden="true"></i>
-            <span>Image Generator</span>
+            <span>Chota Dhamaka</span>
         </button>
         <button class="tab" id="tab-more-tools" data-tab="more-tools" role="tab" aria-selected="false" aria-controls="more-tools-tab">
             <i class="fas fa-toolbox" aria-hidden="true"></i>
@@ -740,6 +627,25 @@
                 <button class="btn btn--primary" id="confirm-save" type="button">
                     <i class="fas fa-save" aria-hidden="true"></i> Save
                 </button>
+            </footer>
+        </div>
+    </div>
+
+    <div class="modal hidden" id="recent-prompts-modal" role="dialog" aria-modal="true" aria-labelledby="recent-prompts-title">
+        <div class="modal__container">
+            <header class="modal__header">
+                <h3 id="recent-prompts-title"><i class="fas fa-history" aria-hidden="true"></i> Recent Prompts</h3>
+                <button class="icon-button" type="button" data-modal-close>
+                    <span class="icon-button__label">Close</span>
+                    <i class="fas fa-times" aria-hidden="true"></i>
+                </button>
+            </header>
+            <div class="modal__body">
+                <p class="modal__intro">Pick a prompt to reuse or copy. Your five most recent prompts appear here.</p>
+                <div class="prompt-history" id="prompt-history" aria-live="polite"></div>
+            </div>
+            <footer class="modal__footer">
+                <button class="btn btn--outline" type="button" data-modal-close>Close</button>
             </footer>
         </div>
     </div>

--- a/styles/base.css
+++ b/styles/base.css
@@ -330,6 +330,35 @@ a:focus {
   color: var(--theme-warning);
 }
 
+.quality-score.excellent,
+.quality-score.good {
+  color: var(--theme-success);
+}
+
+.quality-score.fair {
+  color: var(--theme-warning);
+}
+
+.quality-score.poor {
+  color: var(--theme-error);
+}
+
+.status-pill.quality-indicator.excellent,
+.status-pill.quality-indicator.good {
+  border-color: rgba(16, 185, 129, 0.6);
+  color: var(--theme-success);
+}
+
+.status-pill.quality-indicator.fair {
+  border-color: rgba(251, 191, 36, 0.6);
+  color: var(--theme-warning);
+}
+
+.status-pill.quality-indicator.poor {
+  border-color: rgba(239, 68, 68, 0.6);
+  color: var(--theme-error);
+}
+
 .help-list {
   display: grid;
   gap: 0.65rem;

--- a/styles/components/buttons.css
+++ b/styles/components/buttons.css
@@ -178,6 +178,66 @@
   border-color: transparent;
 }
 
+.theme-dial {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.theme-swatch {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--theme-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--theme-text);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  transition: transform var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.theme-swatch:focus-visible,
+.theme-swatch:hover {
+  border-color: var(--theme-primary);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.theme-swatch.is-active {
+  border-color: var(--theme-primary);
+  background: rgba(255, 255, 255, 0.12);
+  transform: translateY(-2px);
+}
+
+.theme-swatch__dot {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.2);
+}
+
+.theme-swatch[data-theme="dark_professional"] .theme-swatch__dot {
+  background: linear-gradient(135deg, #0f172a, #1e293b);
+}
+
+.theme-swatch[data-theme="cyberpunk_neon"] .theme-swatch__dot {
+  background: linear-gradient(135deg, #00ff88, #0ea5e9);
+}
+
+.theme-swatch[data-theme="light_modern"] .theme-swatch__dot {
+  background: linear-gradient(135deg, #f8fafc, #bae6fd);
+}
+
+.theme-swatch[data-theme="pastel_dreams"] .theme-swatch__dot {
+  background: linear-gradient(135deg, #f9a8d4, #c4b5fd);
+}
+
+.theme-swatch__label {
+  pointer-events: none;
+}
+
 @media (min-width: 54rem) {
   .btn--compact {
     padding-inline: var(--space-md);

--- a/styles/components/cards.css
+++ b/styles/components/cards.css
@@ -45,24 +45,10 @@
   border-bottom: 1px solid var(--theme-border);
 }
 
-.ai-suggestions {
-  display: grid;
-  gap: var(--space-xs);
-}
-
-.suggestion-item {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  padding: var(--space-sm);
-  border-radius: var(--radius-md);
-  border: 1px dashed rgba(255, 255, 255, 0.12);
-}
-
 .random-btn {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: var(--space-sm);
   padding: var(--space-sm);
   border-radius: var(--radius-md);
@@ -77,6 +63,10 @@
 .random-btn:focus-visible {
   transform: translateY(-1px);
   box-shadow: var(--shadow-sm);
+}
+
+.random-btn .icon {
+  font-size: 1.5rem;
 }
 
 .category-tabs {
@@ -111,10 +101,12 @@
 
 .word-bank {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: var(--space-xs);
   max-height: 420px;
   overflow-y: auto;
   padding-inline-end: var(--space-sm);
+  padding-block: var(--space-xs);
 }
 
 .word-group {
@@ -126,13 +118,16 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding-inline: var(--space-sm);
-  padding-block: 0.4rem;
+  padding-inline: clamp(0.45rem, 0.75rem - (var(--char-length, 0) * 0.01rem), 0.75rem);
+  padding-block: clamp(0.3rem, 0.45rem - (var(--char-length, 0) * 0.005rem), 0.45rem);
   border-radius: var(--radius-pill);
   border: 1px solid var(--theme-border);
   background: rgba(255, 255, 255, 0.03);
-  font-size: var(--text-sm);
+  font-size: clamp(0.55rem, 0.95rem - (var(--char-length, 0) * 0.02rem), 0.95rem);
+  font-weight: 600;
+  letter-spacing: 0.02em;
   cursor: pointer;
+  transition: transform var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .word-item:hover,
@@ -140,6 +135,89 @@
   background: var(--theme-primary);
   color: var(--theme-secondary);
   border-color: transparent;
+  transform: translateY(-1px);
+}
+
+.word-item[hidden] {
+  display: none !important;
+}
+
+.word-bank__empty {
+  grid-column: 1 / -1;
+  padding: var(--space-sm);
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.02);
+  font-size: var(--text-sm);
+  color: var(--theme-text-muted);
+}
+
+.word-library-card,
+.helper-card {
+  background: rgba(18, 18, 18, 0.88);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: clamp(1.25rem, 2vw, 2rem);
+  display: grid;
+  gap: var(--space-md);
+  box-shadow: 0 24px 55px rgba(0, 0, 0, 0.45);
+}
+
+.word-library-card {
+  margin-top: var(--space-lg);
+}
+
+.word-library-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.word-library-card__header p {
+  color: var(--theme-text-muted);
+  font-size: var(--text-sm);
+  margin: 0;
+}
+
+.word-library-card__controls {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.word-library-card__search {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding-inline: var(--space-sm);
+  padding-block: 0.45rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--theme-border);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.word-library-card__search i {
+  color: var(--theme-text-muted);
+}
+
+.word-library-card__search .form-control {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: inherit;
+  padding: 0;
+  min-height: auto;
+}
+
+.word-library-card__search .form-control:focus {
+  box-shadow: none;
+}
+
+.helper-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
 }
 
 .prompt-card {
@@ -310,22 +388,16 @@
   width: 100%;
 }
 
-@media (min-width: 52rem) {
+@media (min-width: 48rem) {
   .image-prompt-grid {
     grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
   }
 
   .more-tools-grid {
-    grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   }
 
   .actions-card .action-toolbar {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 72rem) {
-  .actions-card .action-toolbar {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -23,7 +23,7 @@
   z-index: var(--z-header);
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   padding-block: var(--space-sm);
   padding-inline: clamp(1rem, 4vw, 2.5rem);
   background: linear-gradient(135deg, var(--theme-primary), #22c96a);
@@ -56,27 +56,9 @@
   color: inherit;
 }
 
+.header-actions,
 .app-header__actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-}
-
-.app-header .icon-button {
-  border-color: rgba(255, 255, 255, 0.25);
-  background: rgba(0, 0, 0, 0.18);
-  color: var(--theme-secondary);
-}
-
-.app-header .icon-button:hover,
-.app-header .icon-button:focus-visible {
-  background: rgba(0, 0, 0, 0.28);
-  color: #ffffff;
-}
-
-.header-actions {
   display: none;
-  gap: var(--space-sm);
 }
 
 .app-shell {
@@ -143,8 +125,8 @@
 
 .control-strip {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--space-md);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-lg);
   padding: var(--space-lg);
   border-radius: 16px;
   background: linear-gradient(145deg, rgba(36, 36, 36, 0.9), rgba(18, 18, 18, 0.95));
@@ -167,8 +149,7 @@
   text-transform: uppercase;
 }
 
-.control-strip__group,
-.control-strip__actions {
+.control-strip__group {
   display: grid;
   align-items: start;
   gap: var(--space-xs);
@@ -187,16 +168,9 @@
   gap: var(--space-2xs);
 }
 
-.control-strip__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-sm);
-}
-
-@media (max-width: 48rem) {
-  .control-strip__actions {
-    display: none;
-  }
+.control-strip__helper {
+  font-size: var(--text-sm);
+  color: var(--theme-text-muted);
 }
 
 @media (max-width: 40rem) {
@@ -212,10 +186,9 @@
 
 .app-grid {
   display: grid;
-  gap: var(--space-lg);
+  gap: var(--space-xl);
 }
 
-.app-sidebar,
 .app-secondary {
   display: grid;
   gap: var(--space-md);
@@ -228,8 +201,9 @@
 
 .random-buttons {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: var(--space-sm);
+  align-items: stretch;
 }
 
 .prompt-history {
@@ -263,51 +237,21 @@
   }
 }
 
-@media (min-width: 48rem) {
-  .app-grid {
-    grid-template-columns: 1fr;
-  }
+.control-strip__group--platform {
+  margin-top: 0;
+}
 
+@media (max-width: 40rem) {
   .control-strip {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    align-items: end;
-  }
-
-  .control-strip__group--platform {
-    margin-top: 0;
-  }
-}
-
-@media (min-width: 54rem) {
-  .header-actions {
-    display: flex;
-  }
-}
-
-@media (min-width: 60rem) {
-  .app-grid {
-    grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
-    align-items: start;
-  }
-
-  .app-sidebar {
-    position: sticky;
-    top: calc(var(--space-lg) + 72px);
-    max-height: calc(100vh - 120px);
-    overflow: hidden auto;
-    padding-inline-end: var(--space-sm);
+    padding: var(--space-md);
+    gap: var(--space-md);
   }
 }
 
 @media (min-width: 64rem) {
   .app-grid {
-    grid-template-columns: minmax(0, 320px) minmax(0, 1fr) minmax(0, 320px);
-    gap: var(--space-xl);
-  }
-
-  .control-strip {
-    grid-template-columns: auto minmax(0, 280px) 1fr auto;
-    align-items: center;
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+    align-items: start;
   }
 
   .app-secondary {


### PR DESCRIPTION
## Summary
- remove the legacy sidebar and info toggles while introducing a compact theme preset dial with live status messaging
- integrate the smart word library into the main workspace with searchable, size-aware chips and move random generators/recent prompts into the More Tools area
- simplify prompt actions to copy/save with inline feedback, add a recent prompts modal, and optimize batch generation plus UI messaging for better responsiveness

## Testing
- `python -m http.server 8000` (manual UI verification)

------
https://chatgpt.com/codex/tasks/task_b_68ca5672e4348329ade1bda8f245bc5b